### PR TITLE
Feat/wa 403 uk crm integration webform handler

### DIFF
--- a/docroot/modules/custom/azure_blob_storage/src/Plugin/WebformHandler/AzureWebformHandler.php
+++ b/docroot/modules/custom/azure_blob_storage/src/Plugin/WebformHandler/AzureWebformHandler.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Drupal\dso_overviews\Plugin\WebformHandler;
+namespace Drupal\azure_blob_storage\Plugin\WebformHandler;
 
 use Drupal\Core\Queue\QueueInterface;
 use Drupal\webform\Plugin\WebformHandlerBase;

--- a/docroot/modules/custom/azure_blob_storage/src/Plugin/WebformHandler/AzureWebformHandler.php
+++ b/docroot/modules/custom/azure_blob_storage/src/Plugin/WebformHandler/AzureWebformHandler.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace Drupal\dso_overviews\Plugin\WebformHandler;
+
+use Drupal\Core\Queue\QueueInterface;
+use Drupal\webform\Plugin\WebformHandlerBase;
+use Drupal\webform\WebformSubmissionInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * Emails a webform submission.
+ *
+ * @WebformHandler(
+ *   id = "azure_blob_storage_handler",
+ *   label = @Translation("Azure Blob Storage"),
+ *   category = @Translation("azure"),
+ *   description = @Translation("Transfers webform submissions to the Azure Blob storage."),
+ *   cardinality = \Drupal\webform\Plugin\WebformHandlerInterface::CARDINALITY_SINGLE,
+ *   results = \Drupal\webform\Plugin\WebformHandlerInterface::RESULTS_PROCESSED,
+ *   submission = \Drupal\webform\Plugin\WebformHandlerInterface::SUBMISSION_REQUIRED,
+ * )
+ */
+class AzureWebformHandler extends WebformHandlerBase {
+
+  /**
+   * The 'azure_blob_storage_queue'.
+   *
+   * @var \Drupal\Core\Queue\QueueInterface
+   */
+  private readonly QueueInterface $queue;
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition): AzureWebformHandler {
+    $instance = parent::create($container, $configuration, $plugin_id, $plugin_definition);
+    $instance->queue = $container->get('queue')->get('azure_blob_storage_queue');
+
+    return $instance;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function postSave(WebformSubmissionInterface $webform_submission, $update = TRUE): void {
+
+    // Add the submission data to the queue so it can be restructured and pushed
+    // to the Azure Blob Storage in a separate process that won't slow down the
+    // confirmation page displaying.
+    $item = [
+      'webform_id' => $webform_submission->getWebform()->id(),
+      'sid' => $webform_submission->id(),
+    ];
+
+    $this->queue->createItem($item);
+  }
+
+}


### PR DESCRIPTION
Features some deviations from the description on WA-403:

- The restructuring of the data is done inside the queue and not in the webform handler: this is to avoid process potentially large amounts of data on form submit, and storing that data in the database until the queue runs. Processing in the queue means no data is stored, and the processing happens on cron.
- The data stored in the blob does not include webform_last_updated as an indicator of when the webform was last updated: Webforms are config entities and have no concept of a last update date.
- The Submission_date has been added to the data: this seemed like a sensible addition to the data being sent.