### PR TITLE
feat (WA-963): Add queue to copy files from Washmatters to the Orange DAM.

### DIFF
--- a/docroot/modules/custom/wa_migration/src/Plugin/QueueWorker/FileFromUrl.php
+++ b/docroot/modules/custom/wa_migration/src/Plugin/QueueWorker/FileFromUrl.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\wa_migration\Plugin\QueueWorker;
+
+use Drupal\Core\Logger\LoggerChannelFactory;
+use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
+use Drupal\Core\Queue\QueueWorkerBase;
+use Drupal\Core\StringTranslation\StringTranslationTrait;
+use Drupal\wa_orange_dam\Service\Api;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * Defines 'wa_migration_washmatters_files' queue worker.
+ *
+ * @QueueWorker(
+ *   id = "wa_migration_washmatters_files",
+ *   title = @Translation("Washmatters Files"),
+ * )
+ */
+final class FileFromUrl extends QueueWorkerBase implements ContainerFactoryPluginInterface {
+
+  use StringTranslationTrait;
+
+  /**
+   * Constructs a new FileFromUrl instance.
+   */
+  public function __construct(
+    array $configuration,
+    $plugin_id,
+    $plugin_definition,
+    private readonly Api $api,
+    private readonly LoggerChannelFactory $loggerChannelFactory,
+  ) {
+    parent::__construct($configuration, $plugin_id, $plugin_definition);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition): self {
+    return new self(
+      $configuration,
+      $plugin_id,
+      $plugin_definition,
+      $container->get('wa_orange_dam.api'),
+      $container->get('logger.factory'),
+    );
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function processItem($data): void {
+    if ($data) {
+      $error = TRUE;
+
+      if ($return = $this->api->createFile($data, 'WI11SF0L')) {
+        if (isset($return['isSuccess'])) {
+          $error = FALSE;
+        }
+      }
+
+      if ($error) {
+        $this->loggerChannelFactory->get('wa_migration')->error($this->t('Error transferring file from :url', [
+          ':url' => $data,
+        ]));
+      }
+    }
+  }
+
+}

--- a/docroot/modules/custom/wa_migration/wa_migration.install
+++ b/docroot/modules/custom/wa_migration/wa_migration.install
@@ -6,6 +6,7 @@
  */
 
 use Drupal\Core\Config\Config;
+use Drupal\Core\Database\Database;
 
 /**
  * Implements hook_install().
@@ -97,6 +98,38 @@ function wa_migration_update_10002(&$sandbox): void {
         $canon[$term->label()] = $term->id();
       }
     }
+  }
+
+  $sandbox['#finished'] = empty($sandbox['max']) || empty($sandbox['ids']) ? 1 : ($sandbox['max'] - count($sandbox['ids'])) / $sandbox['max'];
+}
+
+/**
+ * Add Washmatters files to a queue.
+ */
+function wa_migration_update_10003(&$sandbox): void {
+  if (!isset($sandbox['ids'])) {
+    Database::setActiveConnection('washmatters_site_migration');
+    $database = Database::getConnection();
+    $query = $database->select('node__field_documents', 'd');
+    $query->leftJoin('media__field_document', 'f', 'd.field_documents_target_id = f.entity_id');
+    $query->leftJoin('file_managed', 'fm', 'fm.fid = f.field_document_target_id');
+    $query->fields('fm', ['uri']);
+    $query->condition('d.bundle', 'publication');
+    $sandbox['ids'] = [];
+    $results = $query->execute()->fetchAll();
+
+    foreach ($results as $result) {
+      $sandbox['ids'][] = $result->uri;
+    }
+
+    $sandbox['max'] = count($sandbox['ids']);
+
+    Database::setActiveConnection();
+  }
+
+  if ($url = array_pop($sandbox['ids'])) {
+    $item = (str_starts_with($url, 'public://')) ? str_replace('public://', 'https://washmatters.wateraid.org/sites/g/files/jkxoof256/files/', $url) : $url;
+    \Drupal::queue('wa_migration_washmatters_files')->createItem($item);
   }
 
   $sandbox['#finished'] = empty($sandbox['max']) || empty($sandbox['ids']) ? 1 : ($sandbox['max'] - count($sandbox['ids'])) / $sandbox['max'];

--- a/docroot/modules/custom/wa_migration/wa_migration.module
+++ b/docroot/modules/custom/wa_migration/wa_migration.module
@@ -104,3 +104,31 @@ function wa_migration_copy_migrations(array $suffixes = []): void {
     }
   }
 }
+
+/**
+ * Implements hook_cron().
+ */
+function wa_migration_cron(): void {
+
+  // Manually trigger the queue so that we can create one file every cron run,
+  // as the API process is a little slow and we don't want to choke it.
+  $queue = \Drupal::queue('wa_migration_washmatters_files');
+
+  if ($queue_item = $queue->claimItem()) {
+
+    /** @var \Drupal\Core\Queue\QueueWorkerInterface $queue_worker */
+    $queue_worker = \Drupal::service('plugin.manager.queue_worker')
+      ->createInstance('wa_migration_washmatters_files');
+
+    try {
+      // Process only 1 queue item per cron run.
+      $queue_worker->processItem($queue_item->data);
+      $queue->deleteItem($queue_item);
+    }
+    catch (\Exception $e) {
+      \Drupal::logger('wa_migration')->error(t('Error processing queue item: :error', [
+        ':error' => $e->getMessage(),
+      ]));
+    }
+  }
+}

--- a/docroot/modules/custom/wa_orange_dam/src/Service/Api.php
+++ b/docroot/modules/custom/wa_orange_dam/src/Service/Api.php
@@ -135,6 +135,34 @@ final class Api {
   }
 
   /**
+   * Helper to create a file on the Orange DAM.
+   *
+   * @param string $file_url
+   *   A url to the file.
+   * @param string $folder_id
+   *   The folder to copy the file into.
+   * @param string|NULL $bearer
+   *   The bearer token. Optional.
+   *
+   * @return array
+   */
+  public function createFile(string $file_url, string $folder_id, string $bearer = NULL): array {
+    $options = [
+      'form_params' => [
+        'folderRecordID' => $folder_id,
+        'fileURL' => $file_url,
+        'fileName' => basename($file_url),
+        'importMode' => 'ProcessInLine',
+      ],
+      'headers' => [
+        'content-type' => 'application/x-www-form-urlencoded',
+      ]
+    ];
+
+    return $this->call($this->base . '/webapi/mediafile/import/upload/uploadmediawithurl_45L_v1', 'POST', $bearer, $options);
+  }
+
+  /**
    * Call the API.
    *
    * @param string $url
@@ -143,23 +171,33 @@ final class Api {
    *   A valid http method.
    * @param string|null $bearer
    *   The bearer. Defaults to the bearer in settings if empty.
+   * @param array $options
+   *   An array of options to pass the the http_library.
    *
    * @return array
    *   The result of the API call. Empty on error.
    */
-  private function call(string $url, string $method, ?string $bearer = NULL): array {
+  private function call(string $url, string $method, ?string $bearer = NULL, array $options = []): array {
     $return = [];
 
     $bearer = ($bearer) ?? Settings::get('orange_dam_bearer');
+    $headers = [
+      'accept' => 'application/json',
+      'Authorization' => 'Bearer ' . $bearer,
+      'content-type' => 'application/json',
+    ];
+
+    if (isset($options['headers'])) {
+      $options['headers'] += $headers;
+    }
+    else {
+      $options += [
+        'headers' => $headers,
+      ];
+    }
 
     try {
-      $response = $this->httpClient->request($method, $url, [
-        'headers' => [
-          'accept' => 'application/json',
-          'Authorization' => 'Bearer ' . $bearer,
-          'content-type' => 'application/json',
-        ],
-      ]);
+      $response = $this->httpClient->request($method, $url, $options);
 
       if ($body = $response->getBody()->getContents()) {
         $return = Json::decode($body);


### PR DESCRIPTION
This requires the WASHMATTERS (jkxoof256) database to be imported into the washmatters_site_migration database for the environment the code is deployed to. Be aware that running this code will create files in the live Orange DAM: if it's run on dev, test and prod they will have 3 copies of each file.